### PR TITLE
feat(ui): 共通レイアウトにmin-height設定を追加

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
       >
         <Header />
-        <main className="flex-grow">
+        <main className="flex-grow min-h-[calc(100vh-144px)]">
           {children}
         </main>
         <Footer />

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3,9 +3,8 @@ import ApiTest from "../components/api-test";
 
 export default function Home() {
   return (
-    <div>
-      <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-        <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+    <div className="p-8 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+      <div className="flex flex-col gap-[32px] items-center sm:items-start">
           <Image
             className="dark:invert"
             src="/next.svg"
@@ -51,55 +50,7 @@ export default function Home() {
             >
               Read our docs
             </a>
-          </div>
-        </main>
-        <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-          <a
-            className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-            href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              aria-hidden
-              src="/file.svg"
-              alt="File icon"
-              width={16}
-              height={16}
-            />
-            Learn
-          </a>
-          <a
-            className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-            href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              aria-hidden
-              src="/window.svg"
-              alt="Window icon"
-              width={16}
-              height={16}
-            />
-            Examples
-          </a>
-          <a
-            className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-            href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              aria-hidden
-              src="/globe.svg"
-              alt="Globe icon"
-              width={16}
-              height={16}
-            />
-            Go to nextjs.org →
-          </a>
-        </footer>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
Issue #4「共通レイアウトの適用」に対応し、すべてのページで一貫したレイアウトを実現しました。

## 変更内容
- `app/layout.tsx`のmainタグに`min-h-[calc(100vh-144px)]`を追加
- `app/page.tsx`から重複するfooter要素を削除し、共通レイアウトに統一
- ヘッダー（64px）+ フッター（80px）= 144px の計算に基づく設定

## 達成した受け入れ基準
- ✅ すべてのページでHeaderとFooterが表示される
- ✅ コンテンツが少ない場合でもFooterが画面下部に固定される  
- ✅ スクロール時もレイアウトが安定している

## テスト結果
- ✅ ESLint: エラーなし
- ✅ TypeScript型チェック: エラーなし
- ✅ 開発サーバーでの動作確認済み

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)