### PR TITLE
feat: 試験一覧画面の実装

### DIFF
--- a/backend/app/controllers/api/tests_controller.rb
+++ b/backend/app/controllers/api/tests_controller.rb
@@ -1,0 +1,42 @@
+module Api
+  class TestsController < ApplicationController
+    skip_before_action :verify_csrf_token, only: [:index]
+
+    # GET /api/tests
+    def index
+      tests = Test.includes(:test_sessions, :pass_mark).all
+      render json: { tests: tests.map { |test| test_response(test) } }, status: :ok
+    rescue StandardError => e
+      render json: { error: e.message }, status: :internal_server_error
+    end
+
+    private
+
+    # 試験データをJSON用に整形するヘルパーメソッド
+    def test_response(test)
+      {
+        id: test.id,
+        year: test.year,
+        questions_count: calculate_questions_count(test),
+        pass_mark: pass_mark_response(test.pass_mark),
+        created_at: test.created_at
+      }
+    end
+
+    # 合格基準データを整形するヘルパーメソッド
+    def pass_mark_response(pass_mark)
+      return nil unless pass_mark
+
+      {
+        required_score: pass_mark.required_score,
+        required_practical_score: pass_mark.required_practical_score,
+        total_score: pass_mark.total_score
+      }
+    end
+
+    # 問題数を計算するヘルパーメソッド
+    def calculate_questions_count(test)
+      test.test_sessions.sum { |session| session.questions.count }
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
 
     # Guest user routes
     post "guest_sessions", to: "guest_sessions#create"
+
+    # Tests routes
+    resources :tests, only: [:index]
   end
 
   # Defines the root path route ("/")

--- a/backend/spec/controllers/api/tests_controller_spec.rb
+++ b/backend/spec/controllers/api/tests_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Api::TestsController, type: :controller do
+  before(:each) do
+    Test.destroy_all
+  end
+
+  describe 'GET #index' do
+    context '試験が存在する場合' do
+      let!(:test1) { create(:test, year: "第58回") }
+      let!(:test2) { create(:test, year: "第57回") }
+      let!(:test3) { create(:test, year: "第56回") }
+
+      # test1に関連データを作成
+      let!(:pass_mark1) { create(:pass_mark, test: test1, required_score: 168, required_practical_score: 41, total_score: 280) }
+      let!(:session1_morning) { create(:test_session, :morning, test: test1) }
+      let!(:session1_afternoon) { create(:test_session, :afternoon, test: test1) }
+      let!(:questions1) { create_list(:question, 5, test_session: session1_morning) }
+      let!(:questions2) { create_list(:question, 5, test_session: session1_afternoon) }
+
+      # test2に関連データを作成
+      let!(:pass_mark2) { create(:pass_mark, test: test2) }
+      let!(:session2) { create(:test_session, test: test2) }
+      let!(:questions3) { create_list(:question, 3, test_session: session2) }
+
+      it 'HTTPステータス200を返す' do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'すべての試験を返す' do
+        get :index
+        json = JSON.parse(response.body)
+        expect(json["tests"].length).to eq(3)
+      end
+
+      it '試験データが正しい構造で返される' do
+        get :index
+        json = JSON.parse(response.body)
+        test = json["tests"].first
+
+        expect(test).to include(
+          "id",
+          "year",
+          "questions_count",
+          "created_at"
+        )
+        expect(test["pass_mark"]).to be_present
+      end
+
+      it '問題数を正しく計算する' do
+        get :index
+        json = JSON.parse(response.body)
+        test = json["tests"].find { |t| t["id"] == test1.id }
+        expect(test["questions_count"]).to eq(10) # 5 + 5
+      end
+
+      it '合格基準が含まれる' do
+        get :index
+        json = JSON.parse(response.body)
+        test = json["tests"].find { |t| t["id"] == test1.id }
+
+        expect(test["pass_mark"]).to eq({
+          "required_score" => 168,
+          "required_practical_score" => 41,
+          "total_score" => 280
+        })
+      end
+    end
+
+    context '試験が存在しない場合' do
+      it 'HTTPステータス200を返す' do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+
+      it '空の配列を返す' do
+        get :index
+        json = JSON.parse(response.body)
+        expect(json["tests"]).to eq([])
+      end
+    end
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://backend:3001/api
+      - NEXT_PUBLIC_API_URL=http://backend:3000
     depends_on:
       - backend
     networks:
@@ -34,7 +34,7 @@ services:
       - db
     networks:
       - kokushi-network
-    command: bundle exec rails server -b 0.0.0.0 -p 3000
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails server -b 0.0.0.0 -p 3000"
 
   db:
     image: postgres:16-alpine

--- a/frontend/app/tests/page.tsx
+++ b/frontend/app/tests/page.tsx
@@ -1,8 +1,55 @@
-export default function Tests() {
+import { TestSelectButton } from "@/components/tests/TestSelectButton";
+import type { TestsResponse } from "@/types/test";
+
+// 動的レンダリングを強制（APIからデータを取得するため）
+export const dynamic = 'force-dynamic';
+
+async function getTests(): Promise<TestsResponse> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+  try {
+    const res = await fetch(`${apiUrl}/api/tests`, {
+      cache: "no-store", // 常に最新データを取得
+    });
+
+    if (!res.ok) {
+      throw new Error("Failed to fetch tests");
+    }
+
+    return res.json();
+  } catch (error) {
+    console.error("Error fetching tests:", error);
+    return { tests: [] };
+  }
+}
+
+export default async function TestsPage() {
+  const data = await getTests();
+  const tests = data.tests;
+
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-6">試験一覧</h1>
-      {/* TODO: 試験一覧コンテンツを実装 */}
+      <div className="mb-8">
+        <h2 className="text-2xl font-bold mb-2 flex items-center gap-2">
+          <span className="text-blue-600">📅</span>
+          年度から選択
+        </h2>
+      </div>
+
+      {tests.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-muted-foreground">試験データがありません</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {tests.map((test) => (
+            <TestSelectButton
+              key={test.id}
+              test={test}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/tests/TestSelectButton.tsx
+++ b/frontend/components/tests/TestSelectButton.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+import type { Test } from "@/types/test";
+
+interface TestSelectButtonProps {
+  test: Test;
+  className?: string;
+}
+
+export function TestSelectButton({
+  test,
+  className = ''
+}: TestSelectButtonProps) {
+  const handleClick = () => {
+    // TODO: 試験詳細ページへの遷移を実装
+    console.log("Test clicked:", test.id);
+    // 実装時: import { useRouter } from 'next/navigation';
+    // const router = useRouter();
+    // router.push(`/tests/${test.id}`);
+  };
+
+  const baseClasses = 'w-full px-6 py-4 text-center font-semibold text-gray-700 bg-blue-50 rounded-lg border-2 border-blue-200 hover:bg-blue-100 hover:border-blue-300 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2';
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`${baseClasses} ${className}`}
+    >
+      {test.year}
+    </button>
+  );
+}

--- a/frontend/types/test.ts
+++ b/frontend/types/test.ts
@@ -1,0 +1,20 @@
+// 合格基準の型定義
+export interface PassMark {
+  required_score: number;
+  required_practical_score: number;
+  total_score: number;
+}
+
+// 試験の型定義
+export interface Test {
+  id: number;
+  year: string;
+  questions_count: number;
+  pass_mark: PassMark | null;
+  created_at: string;
+}
+
+// API レスポンスの型定義
+export interface TestsResponse {
+  tests: Test[];
+}


### PR DESCRIPTION
## 概要
Issue #56 に基づき、試験一覧画面を実装しました。

## 実装内容

### バックエンド
- `Api::TestsController` の実装（TDDで実装）
- GET `/api/tests` エンドポイントの追加
- 試験データ、合格基準、問題数を含むJSONレスポンス

### フロントエンド
- `TestSelectButton` コンポーネントの作成
- 試験一覧ページ (`/tests`) の実装
- 年度ごとにシンプルなボタン形式で表示
- レスポンシブデザイン（1〜4カラムグリッド）

## テスト
- ✅ バックエンドテスト: 230例すべて成功
- ✅ フロントエンドリント: エラーなし

Closes #56